### PR TITLE
Add a limit for the response payload for ALB

### DIFF
--- a/doc_source/limits.md
+++ b/doc_source/limits.md
@@ -19,7 +19,8 @@ The following limits apply to function configuration, deployments, and execution
 | Function [timeout](resource-model.md) | 900 seconds \(15 minutes\) | 
 | Function [environment variables](env_variables.md) | 4 KB | 
 | Function [layers](configuration-layers.md) | 5 layers | 
-| [Invocation payload](invoking-lambda-functions.md) \(request and response\) |  6 MB \(synchronous\) 256 KB \(asynchronous\)  | 
+| [Invocation payload](invoking-lambda-functions.md) \(request and response\) |  6 MB \(synchronous\) 256 KB \(asynchronous\)  |
+| Response payload | 1MB \(ALB trigger\) |
 | [Deployment package](deployment-package-v2.md) size |  50 MB \(zipped\) 250 MB \(unzipped, including layers\) 3 MB \(console editor\)  | 
 | Test events \(console editor\) | 10 | 
 | `/tmp` directory storage | 512 MB | 


### PR DESCRIPTION
*Description of changes:*

The lambda limits page does not address the newly imposed limit of 1MB response payloads when using ALB as a trigger.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
